### PR TITLE
updated version of through in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "through": "~0.0",
+    "through": "2.3.4",
     "msgpack-browserify": "0.0.0",
     "bops": "0.0.6"
   },


### PR DESCRIPTION
npm complains because msgpack-stream installs 0.0.4 of through which doesn't have a repository property set in package.json so upped through to latest version, msgpack-stream tests pass
